### PR TITLE
Require exhaustive matches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
 language: ruby
+dist: trusty
 sudo: false
 cache: bundler
 bundler_args: --without tools
+script:
+  - bundle exec rake
+after_success:
+  - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
   - 2.1
   - 2.2
-  - 2.3.0
-  - rbx
-  - jruby-9000
-  - ruby-head
-  - jruby-head
-before_install:
-  - gem update bundler
-matrix:
-  allow_failures:
-    - rvm: ruby-head
-    - rvm: jruby-head
+  - 2.3.1
+  - jruby-9.1.5.0
+env:
+  global:
+    - JRUBY_OPTS='--dev -J-Xmx1024M'
 addons:
   code_climate:
     repo_token: cec3ffbd851658b020e33353508235e82685c2dbea045147051437c956a79285

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source "https://rubygems.org"
 gemspec
 
 group :test do
-  gem "codeclimate-test-reporter", "~> 0.5.0"
+  gem "simplecov"
+  gem "codeclimate-test-reporter"
   gem "dry-monads", "~> 0.0.2"
 end
 

--- a/lib/dry/matcher/evaluator.rb
+++ b/lib/dry/matcher/evaluator.rb
@@ -1,5 +1,3 @@
-require "set"
-
 module Dry
   class Matcher
     NonExhaustiveMatchError = Class.new(StandardError)
@@ -9,7 +7,7 @@ module Dry
         @cases = cases
         @result = result
 
-        @handled = ::Set.new
+        @unhandled_cases = @cases.keys.map(&:to_sym)
         @matched = false
         @output = nil
       end
@@ -29,15 +27,15 @@ module Dry
       def method_missing(name, *args, &block)
         return super unless @cases.key?(name)
 
-        @handled.add name
+        @unhandled_cases.delete name
         handle_case @cases[name], *args, &block
       end
 
       private
 
       def ensure_exhaustive_match
-        if (not_handled = @cases.keys - @handled.to_a).any?
-          ::Kernel.raise NonExhaustiveMatchError, "cases +#{not_handled.join(', ')}+ not handled"
+        if @unhandled_cases.any?
+          ::Kernel.raise NonExhaustiveMatchError, "cases +#{@unhandled_cases.join(', ')}+ not handled"
         end
       end
 

--- a/lib/dry/matcher/evaluator.rb
+++ b/lib/dry/matcher/evaluator.rb
@@ -1,15 +1,24 @@
+require "set"
+
 module Dry
   class Matcher
+    NonExhaustiveMatchError = Class.new(StandardError)
+
     class Evaluator < BasicObject
       def initialize(result, cases)
         @cases = cases
         @result = result
+
+        @handled = ::Set.new
         @matched = false
         @output = nil
       end
 
       def call
         yield self
+
+        ensure_exhaustive_match
+
         @output
       end
 
@@ -20,10 +29,17 @@ module Dry
       def method_missing(name, *args, &block)
         return super unless @cases.key?(name)
 
+        @handled.add name
         handle_case @cases[name], *args, &block
       end
 
       private
+
+      def ensure_exhaustive_match
+        if (not_handled = @cases.keys - @handled.to_a).any?
+          ::Kernel.raise NonExhaustiveMatchError, "cases +#{not_handled.join(', ')}+ not handled"
+        end
+      end
 
       def handle_case(kase, *pattern)
         return @output if @matched

--- a/spec/integration/matcher_spec.rb
+++ b/spec/integration/matcher_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Dry::Matcher do
 
       def call_match(input)
         matcher.(input) do |m|
-          m.success { }
+          m.success
 
           m.failure :my_error do |v|
             "Pattern-matched failure: #{v}"

--- a/spec/integration/matcher_spec.rb
+++ b/spec/integration/matcher_spec.rb
@@ -45,7 +45,24 @@ RSpec.describe Dry::Matcher do
       expect(call_match(input)).to eq "Failure: No!"
     end
 
+    it "requires an exhaustive match" do
+      input = Dry::Monads::Right("Yes!")
+
+      expect {
+        matcher.(input) do |m|
+          m.success { |v| "Success: #{v}" }
+        end
+      }.to raise_error Dry::Matcher::NonExhaustiveMatchError
+    end
+
     context "with patterns" do
+      let(:success_case) {
+        Dry::Matcher::Case.new(
+          match: -> result { result.first == :ok },
+          resolve: -> result { result.last },
+        )
+      }
+
       let(:failure_case) {
         Dry::Matcher::Case.new(
           match: -> result, failure_type {
@@ -57,6 +74,8 @@ RSpec.describe Dry::Matcher do
 
       def call_match(input)
         matcher.(input) do |m|
+          m.success { }
+
           m.failure :my_error do |v|
             "Pattern-matched failure: #{v}"
           end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,8 @@
-if RUBY_ENGINE == "ruby"
-  require "codeclimate-test-reporter"
-  CodeClimate::TestReporter.start
-
-  SimpleCov.start do
-    add_filter "/spec/"
-  end
+if RUBY_ENGINE == "ruby" && RUBY_VERSION >= "2.3"
+  require "simplecov"
+  SimpleCov.start
 end
+
 
 begin
   require "byebug"


### PR DESCRIPTION
This changes makes it required for a match block to provide handlers for all the cases in the matcher. For example, when using `Dry::Matcher::EitherMatcher`, both `success` and `failure` blocks must be provided. A failure to handle all the cases will result in a `NonExhaustiveMatchError`.

This change should make matcher usage more robust, since it less likely that certain conditions are forgotten/ignored.

Since this is a behavioural change, I'd be happy to hear thoughts about this.

In our usage of dry-matcher at Icelab, this would continue to work fine for us, since in 99% of our cases we already provide success/failure handlers, and in the 1%, we should probably just go and add the missing one :)
