### PR TITLE
Allow wildcard handler

### DIFF
--- a/lib/dry/matcher/evaluator.rb
+++ b/lib/dry/matcher/evaluator.rb
@@ -11,6 +11,7 @@ module Dry
         @result = result
 
         @unhandled_cases = @cases.keys.map(&:to_sym)
+        @else_handler = -> { ensure_exhaustive_match }
         @matched = false
         @output = nil
       end
@@ -18,14 +19,17 @@ module Dry
       def call
         yield self
 
-        ensure_exhaustive_match
+        @else_handler.call
 
         @output
       end
 
       def else(*args, &block)
-        @unhandled_cases.each { |name| handle_case(@cases[name], *args, &block) }
-        @unhandled_cases.clear
+        @else_handler = -> do
+          @unhandled_cases.each do |name|
+            handle_case(@cases[name], *args, &block)
+          end
+        end
       end
 
       # Checks whether `cases` given to {#initialize} contains one called `name`

--- a/lib/dry/matcher/evaluator.rb
+++ b/lib/dry/matcher/evaluator.rb
@@ -23,6 +23,11 @@ module Dry
         @output
       end
 
+      def else(*args, &block)
+        @unhandled_cases.each { |name| handle_case(@cases[name], *args, &block) }
+        @unhandled_cases.clear
+      end
+
       # Checks whether `cases` given to {#initialize} contains one called `name`
       # @param [String] name
       # @param [Boolean] include_private

--- a/spec/integration/matcher_spec.rb
+++ b/spec/integration/matcher_spec.rb
@@ -56,48 +56,61 @@ RSpec.describe Dry::Matcher do
     end
 
     context "with wildcard handler" do
+      let(:less_case) {
+        Dry::Matcher::Case.new(match: -> result { result < 0 })
+      }
+
+      let(:zero_case) {
+        Dry::Matcher::Case.new(match: -> result { result == 0 })
+      }
+
       let(:one_case) {
         Dry::Matcher::Case.new(match: -> result { result == 1 })
       }
 
-      let(:two_case) {
-        Dry::Matcher::Case.new(match: -> result { result == 2 })
-      }
-
-      let(:three_case) {
-        Dry::Matcher::Case.new(match: -> result { result == 3 })
+      let(:greater_case) {
+        Dry::Matcher::Case.new(match: -> result { result > 1 })
       }
 
       let(:matcher) {
         Dry::Matcher.new(
+          less: less_case,
+          zero: zero_case,
           one: one_case,
-          two: two_case,
-          three: three_case,
+          greater: greater_case
         )
       }
 
       def call_match(input)
         matcher.(input) do |m|
-          m.one do |v|
-            "One: #{1}"
+          m.less do |v|
+            "Less: #{v}"
           end
 
           m.else do |v|
-            "Two or Three: #{v}"
+            "Zero or One: #{v}"
+          end
+
+          m.greater do |v|
+            "Greater: #{v}"
           end
         end
       end
 
-      it "matches on one" do
-        expect(call_match(1)).to eq "One: 1"
+      it "matches on -1" do
+        expect(call_match(-1)).to eq "Less: -1"
       end
 
-      it "matches on two" do
-        expect(call_match(2)).to eq "Two or Three: 2"
+      it "matches on 0" do
+        expect(call_match(0)).to eq "Zero or One: 0"
       end
 
-      it "matches on three" do
-        expect(call_match(3)).to eq "Two or Three: 3"
+      it "matches on 1" do
+        expect(call_match(1)).to eq "Zero or One: 1"
+      end
+
+      it "matches on 2" do
+        expect(call_match(2)).to eq "Greater: 2"
       end
     end
 

--- a/spec/integration/matcher_spec.rb
+++ b/spec/integration/matcher_spec.rb
@@ -55,6 +55,52 @@ RSpec.describe Dry::Matcher do
       }.to raise_error Dry::Matcher::NonExhaustiveMatchError
     end
 
+    context "with wildcard handler" do
+      let(:one_case) {
+        Dry::Matcher::Case.new(match: -> result { result == 1 })
+      }
+
+      let(:two_case) {
+        Dry::Matcher::Case.new(match: -> result { result == 2 })
+      }
+
+      let(:three_case) {
+        Dry::Matcher::Case.new(match: -> result { result == 3 })
+      }
+
+      let(:matcher) {
+        Dry::Matcher.new(
+          one: one_case,
+          two: two_case,
+          three: three_case,
+        )
+      }
+
+      def call_match(input)
+        matcher.(input) do |m|
+          m.one do |v|
+            "One: #{1}"
+          end
+
+          m.else do |v|
+            "Two or Three: #{v}"
+          end
+        end
+      end
+
+      it "matches on one" do
+        expect(call_match(1)).to eq "One: 1"
+      end
+
+      it "matches on two" do
+        expect(call_match(2)).to eq "Two or Three: 2"
+      end
+
+      it "matches on three" do
+        expect(call_match(3)).to eq "Two or Three: 3"
+      end
+    end
+
     context "with patterns" do
       let(:success_case) {
         Dry::Matcher::Case.new(


### PR DESCRIPTION
It would be amazing to provide some sort of wildcard method, that matches all unhandled cases. Think about a matcher with 4 cases ```:success, :invalid, :not_found, :unauthorized``` and a caller caring only about 2 of them and likes to process the rest in a generic way:

```ruby
matcher.(input) do |m|
  m.success { |v| "Yay! You did something: #{v}" }
  m.invalid { |v| "Hmm... You did something, but wrong: #{v.errors}" }
  m.else { |v| "No! Something went really wrong..." }
end
```

@timriley  what do you think?