### PR TITLE
Add the ability to pass match pattern to the resolver

### DIFF
--- a/lib/dry/matcher/case.rb
+++ b/lib/dry/matcher/case.rb
@@ -27,9 +27,15 @@ module Dry
       # as `resolve:` argument
       #
       # @param [Object] value
+      # @param [<Object>] pattern optional pattern given after the `value` to
+      #   `resolve:` callable
       # @return [Object] result resolved from given `value`
-      def resolve(value)
-        @resolve.(value)
+      def resolve(value, *pattern)
+        if @resolve.arity == 1
+          @resolve.(value)
+        else
+          @resolve.(value, *pattern)
+        end
       end
     end
   end

--- a/lib/dry/matcher/evaluator.rb
+++ b/lib/dry/matcher/evaluator.rb
@@ -67,7 +67,7 @@ module Dry
 
         if kase.matches?(@result, *pattern)
           @matched = true
-          @output = yield(kase.resolve(@result))
+          @output = yield(kase.resolve(@result, *pattern))
         end
       end
     end


### PR DESCRIPTION
This will enable to resolve matched values using match patterns.

# Motivition

I use Trailblazer's [Operation](http://trailblazer.to/gems/operation/2.0/index.html) to describe the business logic of my app. An operation is a sequence of `step`s which are executed in order. A failing step halts subsequent operation execution. I use `dry-matcher` to determine the outcome of an entire operation, each `dry-matcher` case corresponds to one possible outcome: `:success` (all steps are finished successfully), `:not_found`, `:unauthorized`, `:invalid` (validation failure). 

An operation can have multiple validation groups which have different names. To be able to match on particular validation failure using a single case definition (`invalid`), I use an additional match pattern (match on validation name):

``` ruby
invalid = Dry::Matcher::Case.new(
  match: ->(result, name: 'default') do
    result.failure? && result["result.contract.#{name}"]&.failure?
  end
)

# ...

matcher = Dry::Matcher.new(
  # ...
  invalid: invalid,
  # ...
)

# ...

matcher.(operation_result) do |m|
  # ...

  m.invalid(name: :param) do |result|
    render json: result['result.contract.name'].errors, status: 422
  end

  m.invalid do |result|
    render json: result['result.contract.default'].errors, status: 422
  end

  # ...
end
```

The problem is that I cannot use match pattern in `:resolve` to retrieve data (errors hash) associated with the particular validation failure. With this PR, it's made possible:

``` ruby
invalid = Dry::Matcher::Case.new(
  match: ->(result, name: 'default') do
    result.failure? && result["result.contract.#{name}"]&.failure?
  end,
  resolve: ->(result, name: 'default') do
    result["result.contract.#{name}"].errors
  end
)

# ...

matcher.(operation_result) do |result|
  # ...

  m.invalid(name: :param) do |errors|
    render json: errors, status: 422
  end

  m.invalid do |errors|
    render json: errors, status: 422
  end

  # ...
end
```

This is an optional feature which should not break backward compatibility (see arity check [here](https://github.com/smaximov/dry-matcher/blob/9a34c1e9d7c19f233a519e747f2b0ac3ca39c0f0/lib/dry/matcher/case.rb#L34))