### PR TITLE
Rename EitherMatcher to ResultMatcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ script:
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.1
-  - 2.2
-  - 2.3.1
-  - jruby-9.1.5.0
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
+  - jruby-9.1.13.0
 env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.7.0 / to-be-released
+
+## Changed
+
+- `EitherMatcher` was renamed to `ResultMatcher` according to the changes in `dry-monads`. The previous name is still there for backward compatibility, we'll deprecate and drop it in furure releases (flash-gordon in [#13](https://github.com/dry-rb/dry-matcher/pull/13)
+
+[Compare v0.6.0...master](https://github.com/dry-rb/dry-result_matcher/compare/v0.6.0...master)
+
 # 0.6.0 / 2016-12-19
 
 ## Added

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :test do
   gem "simplecov"
   gem "codeclimate-test-reporter"
-  gem "dry-monads", git: "https://github.com/dry-rb/dry-monads.git"
+  gem "dry-monads", '>= 0.4.0'
 end
 
 group :tools do

--- a/dry-matcher.gemspec
+++ b/dry-matcher.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files          = Dir["README.md", "LICENSE.md", "CHANGELOG.md", "Gemfile", "Rakefile", "lib/**/*", "spec/**/*"]
   spec.require_paths  = ["lib"]
 
-  spec.required_ruby_version = ">= 2.1.0"
+  spec.required_ruby_version = ">= 2.2.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.4.2"

--- a/lib/dry/matcher.rb
+++ b/lib/dry/matcher.rb
@@ -13,10 +13,10 @@ module Dry
     #
     # @example Usage with `dry-monads`
     #   class MonadicOperation
-    #     include Dry::Matcher.for(:call, with: Dry::Matcher::EitherMatcher)
+    #     include Dry::Matcher.for(:call, with: Dry::Matcher::ResultMatcher)
     #
     #     def call
-    #       Dry::Monads::Either::Right.new('Success')
+    #       Dry::Monads::Result::Success.new('Success')
     #     end
     #   end
     #
@@ -71,11 +71,11 @@ module Dry
     #
     # @example Usage with `dry-monads`
     #   require 'dry-monads'
-    #   require 'dry/matcher/either_matcher'
+    #   require 'dry/matcher/result_matcher'
     #
-    #   value = Dry::Monads::Either::Left.new('failure!')
+    #   value = Dry::Monads::Result::Failure.new('failure!')
     #
-    #   Dry::Matcher::EitherMatcher.(value) do |m|
+    #   Dry::Matcher::ResultMatcher.(value) do |m|
     #     m.success { |v| "Yay: #{v}" }
     #     m.failure { |v| "Boo: #{v}" }
     #   end #=> "Boo: failure!"

--- a/lib/dry/matcher/either_matcher.rb
+++ b/lib/dry/matcher/either_matcher.rb
@@ -1,74 +1,7 @@
-require "dry/matcher"
+require "dry/matcher/result_matcher"
 
 module Dry
   class Matcher
-    # Built-in {Matcher} ready to use with `Either` or `Try` monads from
-    # [dry-monads](/gems/dry-monads) or any other compatible gems.
-    #
-    # Provides {Case}s for two matchers:
-    # * `:success` matches `Dry::Monads::Either::Right`
-    #   and `Dry::Monads::Try::Success` (or any other monad that responds to
-    #   `#to_either` returning either monad that is `#right?`)
-    # * `:failure` matches `Dry::Monads::Either::Left` and
-    #   `Dry::Monads::Try::Failure` (or any other monad that responds to
-    #   `#to_either` returning either monad that is `#left?`)
-    #
-    # @return [Dry::Matcher]
-    #
-    # @example Usage with `dry-monads`
-    #   require 'dry-monads'
-    #   require 'dry/matcher/either_matcher'
-    #
-    #   value = Dry::Monads::Either::Right.new('success!')
-    #
-    #   Dry::Matcher::EitherMatcher.(value) do |m|
-    #     m.success do |v|
-    #       "Yay: #{v}"
-    #     end
-    #
-    #     m.failure do |v|
-    #       "Boo: #{v}"
-    #     end
-    #   end #=> "Yay: success!"
-    #
-    # @example Usage with custom monad
-    #   require 'dry/matcher/either_matcher'
-    #
-    #   class CustomBooleanMonad
-    #     def initialize(value); @value = value; end
-    #     attr_reader :value
-    #     alias_method :right?, :value
-    #     def left?; !right?; end
-    #     def to_either; self; end
-    #   end
-    #
-    #   value = CustomBooleanMonad.new(nil)
-    #
-    #   Dry::Matcher::EitherMatcher.(value) do |m|
-    #     m.success { |v| "#{v.inspect} is truthy" }
-    #     m.failure { |v| "#{v.inspect} is falsey" }
-    #   end # => "nil is falsey"
-    EitherMatcher = Dry::Matcher.new(
-      success: Case.new(
-        match: -> result, *pattern {
-          result = result.to_either
-          result.right?
-        },
-        resolve: -> result {
-          result = result.to_either
-          result.value!
-        },
-      ),
-      failure: Case.new(
-        match: -> result, *pattern {
-          result = result.to_either
-          result.left?
-        },
-        resolve: -> result {
-          result = result.to_either
-          result.left
-        },
-      )
-    )
+    EitherMatcher = ResultMatcher
   end
 end

--- a/lib/dry/matcher/result_matcher.rb
+++ b/lib/dry/matcher/result_matcher.rb
@@ -1,0 +1,74 @@
+require "dry/matcher"
+
+module Dry
+  class Matcher
+    # Built-in {Matcher} ready to use with `Result` or `Try` monads from
+    # [dry-monads](/gems/dry-monads) or any other compatible gems.
+    #
+    # Provides {Case}s for two matchers:
+    # * `:success` matches `Dry::Monads::Result::Success`
+    #   and `Dry::Monads::Try::Value` (or any other monad that responds to
+    #   `#to_result` returning result monad that is `#success?`)
+    # * `:failure` matches `Dry::Monads::Result::Failure` and
+    #   `Dry::Monads::Try::Error` (or any other monad that responds to
+    #   `#to_result` returning result monad that is `#failure?`)
+    #
+    # @return [Dry::Matcher]
+    #
+    # @example Usage with `dry-monads`
+    #   require 'dry-monads'
+    #   require 'dry/matcher/result_matcher'
+    #
+    #   value = Dry::Monads::Result::Success.new('success!')
+    #
+    #   Dry::Matcher::ResultMatcher.(value) do |m|
+    #     m.success do |v|
+    #       "Yay: #{v}"
+    #     end
+    #
+    #     m.failure do |v|
+    #       "Boo: #{v}"
+    #     end
+    #   end #=> "Yay: success!"
+    #
+    # @example Usage with custom monad
+    #   require 'dry/matcher/result_matcher'
+    #
+    #   class CustomBooleanMonad
+    #     def initialize(value); @value = value; end
+    #     attr_reader :value
+    #     alias_method :success?, :value
+    #     def failure?; !success?; end
+    #     def to_result; self; end
+    #   end
+    #
+    #   value = CustomBooleanMonad.new(nil)
+    #
+    #   Dry::Matcher::ResultMatcher.(value) do |m|
+    #     m.success { |v| "#{v.inspect} is truthy" }
+    #     m.failure { |v| "#{v.inspect} is falsey" }
+    #   end # => "nil is falsey"
+    ResultMatcher = Dry::Matcher.new(
+      success: Case.new(
+        match: -> result, *pattern {
+          result = result.to_result
+          result.success?
+        },
+        resolve: -> result {
+          result = result.to_result
+          result.value!
+        },
+      ),
+      failure: Case.new(
+        match: -> result, *pattern {
+          result = result.to_result
+          result.failure?
+        },
+        resolve: -> result {
+          result = result.to_result
+          result.failure
+        },
+      )
+    )
+  end
+end

--- a/spec/integration/class_enhancement_spec.rb
+++ b/spec/integration/class_enhancement_spec.rb
@@ -1,13 +1,13 @@
 require "dry-monads"
-require "dry/matcher/either_matcher"
+require "dry/matcher/result_matcher"
 
 RSpec.describe "Class enhancement with Dry::Matcher.for" do
   let(:operation) {
     Class.new do
-      include Dry::Matcher.for(:call, with: Dry::Matcher::EitherMatcher)
+      include Dry::Matcher.for(:call, with: Dry::Matcher::ResultMatcher)
 
       def call(bool)
-        bool ? Dry::Monads::Right("a success") : Dry::Monads::Left("a failure")
+        bool ? Dry::Monads::Success("a success") : Dry::Monads::Failure("a failure")
       end
     end.new
   }
@@ -49,7 +49,7 @@ RSpec.describe "Class enhancement with Dry::Matcher.for" do
       let(:input) { true }
 
       it "returns the result" do
-        expect(result).to eq Dry::Monads::Right("a success")
+        expect(result).to eq Dry::Monads::Success("a success")
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe "Class enhancement with Dry::Matcher.for" do
       let(:input) { false }
 
       it "returns the result" do
-        expect(result).to eq Dry::Monads::Left("a failure")
+        expect(result).to eq Dry::Monads::Failure("a failure")
       end
     end
   end

--- a/spec/integration/matcher_spec.rb
+++ b/spec/integration/matcher_spec.rb
@@ -4,15 +4,15 @@ RSpec.describe Dry::Matcher do
   context "with match cases provided" do
     let(:success_case) {
       Dry::Matcher::Case.new(
-        match: -> result { result.right? },
+        match: -> result { result.success? },
         resolve: -> result { result.value! },
       )
     }
 
     let(:failure_case) {
       Dry::Matcher::Case.new(
-        match: -> result { result.left? },
-        resolve: -> result { result.left },
+        match: -> result { result.failure? },
+        resolve: -> result { result.failure },
       )
     }
 
@@ -36,17 +36,17 @@ RSpec.describe Dry::Matcher do
     end
 
     it "matches on success" do
-      input = Dry::Monads::Right("Yes!")
+      input = Dry::Monads::Success("Yes!")
       expect(call_match(input)).to eq "Success: Yes!"
     end
 
     it "matches on failure" do
-      input = Dry::Monads::Left("No!")
+      input = Dry::Monads::Failure("No!")
       expect(call_match(input)).to eq "Failure: No!"
     end
 
     it "requires an exhaustive match" do
-      input = Dry::Monads::Right("Yes!")
+      input = Dry::Monads::Success("Yes!")
 
       expect {
         matcher.(input) do |m|

--- a/spec/integration/result_matcher_spec.rb
+++ b/spec/integration/result_matcher_spec.rb
@@ -1,10 +1,10 @@
 require "dry-monads"
-require "dry/matcher/either_matcher"
+require "dry/matcher/result_matcher"
 
-RSpec.describe "Dry::Matcher::EitherMatcher" do
+RSpec.describe "Dry::Matcher::ResultMatcher" do
   describe "external matching" do
     subject(:match) {
-      Dry::Matcher::EitherMatcher.(result) do |m|
+      Dry::Matcher::ResultMatcher.(result) do |m|
         m.success do |v|
           "Matched success: #{v}"
         end
@@ -16,7 +16,7 @@ RSpec.describe "Dry::Matcher::EitherMatcher" do
     }
 
     context "successful result" do
-      let(:result) { Dry::Monads::Right("a success") }
+      let(:result) { Dry::Monads::Success("a success") }
 
       it "matches on success" do
         expect(match).to eq "Matched success: a success"
@@ -24,14 +24,14 @@ RSpec.describe "Dry::Matcher::EitherMatcher" do
     end
 
     context "failed result" do
-      let(:result) { Dry::Monads::Left("a failure") }
+      let(:result) { Dry::Monads::Failure("a failure") }
 
       it "matches on failure" do
         expect(match).to eq "Matched failure: a failure"
       end
     end
 
-    context "result convertible to either" do
+    context "result convertible to result" do
       context "converts to success" do
         let(:result) {
           Dry::Monads::Try.lift([StandardError], -> { 'a success' })

--- a/spec/unit/case_spec.rb
+++ b/spec/unit/case_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Dry::Matcher::Case do
 
   describe "#resolve" do
     it "calls the resolve proc with the value" do
-      kase = described_class.new(match: -> * { true }, resolve: resolve = -> value { value.to_s })
+      kase = described_class.new(match: -> * { true }, resolve: -> value { value.to_s })
 
       expect(kase.resolve(123)).to eq "123"
     end


### PR DESCRIPTION
In the latest `dry-monads` release `Either` was renamed to `Result`, this PR reflects this change.