### PR TITLE
CI: Include latest Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,15 @@ language: ruby
 dist: trusty
 cache: bundler
 bundler_args: --without tools
-script:
-  - bundle exec rake
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.2.8
-  - 2.3.5
-  - 2.4.2
-  - jruby-9.1.13.0
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
+  - jruby-9.2.6.0
 env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 dist: trusty
-sudo: false
 cache: bundler
 bundler_args: --without tools
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 gem "bundler"
 gem "rake"
+gem "yard"
 
 group :test do
   gem "codeclimate-test-reporter"
@@ -15,5 +16,4 @@ end
 group :tools do
   gem "byebug", platform: :mri
   gem "pry"
-  gem "yard"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,18 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "bundler"
+gem "rake"
+
 group :test do
-  gem "simplecov"
   gem "codeclimate-test-reporter"
   gem "dry-monads", '>= 0.4.0'
+  gem "rspec", "~> 3.8"
+  gem "simplecov"
 end
 
 group :tools do
   gem "byebug", platform: :mri
   gem "pry"
+  gem "yard"
 end

--- a/dry-matcher.gemspec
+++ b/dry-matcher.gemspec
@@ -17,10 +17,4 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ["lib"]
 
   spec.required_ruby_version = ">= 2.2.0"
-
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.4.2"
-  spec.add_development_dependency "rspec", "~> 3.3.0"
-  spec.add_development_dependency "simplecov", "~> 0.10.0"
-  spec.add_development_dependency "yard"
 end


### PR DESCRIPTION
This PR updates the CI matrix to latest released versions.

- removes an unused setting in Travis
- drops explicit Travis configuration which was default
- moves gem dev deps into the Gemfile (I made a best guess about where to place yard) in order to support Bundler 2