### PR TITLE
CI: use latest Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ after_success:
 rvm:
   - 2.3.8
   - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.5.5
+  - 2.6.2
   - jruby-9.2.6.0
 env:
   global:


### PR DESCRIPTION
This PR updates the CI matrix to use the latest versions.