### PR TITLE
CI: Use 2.4.6, 2.6.3, jruby-9.2.7.0, drop 2.3.8 (EOL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ bundler_args: --without tools
 after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
-  - 2.3.8
   - 2.4.6
   - 2.5.5
   - 2.6.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.2
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
 env:
   global:
     - JRUBY_OPTS='--dev -J-Xmx1024M'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ after_success:
 rvm:
   - 2.4.6
   - 2.5.5
-  - 2.6.2
+  - 2.6.3
   - jruby-9.2.7.0
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ after_success:
   - '[ -d coverage ] && bundle exec codeclimate-test-reporter'
 rvm:
   - 2.3.8
-  - 2.4.5
+  - 2.4.6
   - 2.5.5
   - 2.6.2
   - jruby-9.2.6.0


### PR DESCRIPTION
This PR updates the CI matrix.