### PR TITLE
Allow pattern matching in ResultMatcher

### DIFF
--- a/lib/dry/matcher/result_matcher.rb
+++ b/lib/dry/matcher/result_matcher.rb
@@ -50,9 +50,9 @@ module Dry
     #   end # => "nil is falsey"
     ResultMatcher = Dry::Matcher.new(
       success: Case.new(
-        match: -> result, *pattern {
+        match: -> result, *patterns {
           result = result.to_result
-          result.success?
+          result.success? && (patterns.none? || patterns.include?(result.value!))
         },
         resolve: -> result {
           result = result.to_result
@@ -60,9 +60,9 @@ module Dry
         },
       ),
       failure: Case.new(
-        match: -> result, *pattern {
+        match: -> result, *patterns {
           result = result.to_result
-          result.failure?
+          result.failure? && (patterns.none? || patterns.include?(result.failure))
         },
         resolve: -> result {
           result = result.to_result

--- a/spec/integration/result_matcher_spec.rb
+++ b/spec/integration/result_matcher_spec.rb
@@ -53,5 +53,54 @@ RSpec.describe "Dry::Matcher::ResultMatcher" do
         end
       end
     end
+
+    context "multiple branch matching" do
+      subject {
+        Dry::Matcher::ResultMatcher.(result) do |on|
+          on.success(:a) { "Matched specific success: :a" }
+          on.success(:b) { "Matched specific success: :b" }
+          on.success { |v| "Matched general success: #{v}" }
+          on.failure(:a) { "Matched specific failure: :a" }
+          on.failure(:b) { "Matched specific failure: :b" }
+          on.failure { |v| "Matched general failure: #{v}" }
+        end
+      }
+
+      context "specific success for :a" do
+        let(:result) { Dry::Monads::Success(:a) }
+
+        it { is_expected.to eq "Matched specific success: :a"}
+      end
+
+      context "specific success for :b" do
+        let(:result) { Dry::Monads::Success(:b) }
+
+        it { is_expected.to eq "Matched specific success: :b"}
+      end
+
+      context "general success result" do
+        let(:result) { Dry::Monads::Success("a success") }
+
+        it { is_expected.to eq "Matched general success: a success" }
+      end
+
+      context "specific failure for :a" do
+        let(:result) { Dry::Monads::Failure(:a) }
+
+        it { is_expected.to eq "Matched specific failure: :a"}
+      end
+
+      context "specific failure for :b" do
+        let(:result) { Dry::Monads::Failure(:b) }
+
+        it { is_expected.to eq "Matched specific failure: :b"}
+      end
+
+      context "general failure result" do
+        let(:result) { Dry::Monads::Failure("a failure") }
+
+        it { is_expected.to eq "Matched general failure: a failure" }
+      end
+    end
   end
 end


### PR DESCRIPTION
A gotcha that has bitten my team several times is that you cannot
pattern match against the wrapped value of a result in the
ResultMatcher.

Since the [basic matcher documentation][1] shows an example where you
can pattern match against the patterns that you specify in your case
block, this is easy to assume that it's a built-in for the
ResultMatcher.

Adding pattern matching is a simple change that makes the whole of the
ResultMatcher more flexible and more in-line with the examples in the
rest of the documentation.

[1]: https://dry-rb.org/gems/dry-matcher/