### PR TITLE
Use a single block for matching and value resolving

### DIFF
--- a/dry-matcher.gemspec
+++ b/dry-matcher.gemspec
@@ -17,4 +17,6 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ["lib"]
 
   spec.required_ruby_version = ">= 2.4.0"
+
+  spec.add_runtime_dependency "dry-core", ">= 0.4.7"
 end

--- a/lib/dry/matcher.rb
+++ b/lib/dry/matcher.rb
@@ -1,9 +1,12 @@
+require "dry/core/constants"
 require "dry/matcher/case"
 require "dry/matcher/evaluator"
 
 module Dry
   # @see http://dry-rb.org/gems/dry-matcher
   class Matcher
+    include Core::Constants
+
     # Generates a module containing pattern matching for methods listed in
     # `match_methods` argument with behavior defined by `with` matcher
     #

--- a/spec/unit/case_spec.rb
+++ b/spec/unit/case_spec.rb
@@ -1,22 +1,63 @@
 RSpec.describe Dry::Matcher::Case do
-  describe "#matches?" do
-    it "calls the match proc with the value" do
-      kase = described_class.new(match: -> value { value.even? })
-      expect(kase.matches?(2)).to be true
-      expect(kase.matches?(1)).to be false
+  let(:undefined) { Dry::Core::Constants::Undefined }
+
+  describe 'old interface' do
+    describe 'matching' do
+      subject(:kase) { described_class.new(match: -> value { value.even? }) }
+
+      it "calls the match proc with the value" do
+        expect(kase.(2) { :matched }).to be(:matched)
+        expect(kase.(1) { fail }).to be(undefined)
+      end
+    end
+
+    describe 'resolving' do
+      it "calls the resolve proc with the value" do
+        kase = described_class.new(match: -> * { true }, resolve: -> value { value.to_s })
+
+        expect(kase.(123) { |result| result }).to eq "123"
+      end
+
+      it "defaults to passing through the value" do
+        kase = described_class.new(match: -> * { true })
+        expect(kase.(123) { |result| result }).to eq 123
+      end
     end
   end
 
-  describe "#resolve" do
-    it "calls the resolve proc with the value" do
-      kase = described_class.new(match: -> * { true }, resolve: -> value { value.to_s })
+  describe '#call' do
+    describe 'using patterns' do
+      let(:kase) do
+        described_class.new do |value, patterns|
+          if patterns.include?(value)
+            value
+          else
+            undefined
+          end
+        end
+      end
 
-      expect(kase.resolve(123)).to eq "123"
+      it 'uses patterns to match given value' do
+        expect(kase.(3, [1, 2, 3]) { |value| value.to_s }).to eql('3')
+        expect(kase.(4, [1, 2, 3]) { fail }).to be(undefined)
+      end
     end
 
-    it "defaults to passing through the value" do
-      kase = described_class.new(match: -> * { true })
-      expect(kase.resolve(123)).to eq 123
+    describe 'extracting values' do
+      let(:kase) do
+        described_class.new do |(code, value), patterns|
+          if patterns.include?(code)
+            value
+          else
+            undefined
+          end
+        end
+      end
+
+      it 'transforms value by dropping result code' do
+        expect(kase.([:found, 100], [:found, :not_found]) { |value| value.to_s }).to eql('100')
+        expect(kase.([:else, 100], [:found, :not_found]) { fail }).to be(undefined)
+      end
     end
   end
 end


### PR DESCRIPTION
This unifies `match` and `resolve` procs, now `Case.new` takes a block that returns either a resolved value or `Dry::Core::Constants::Undefined`. It's a backward compatible change that speeds up pattern matching and will make the built-in result matcher even more flexible (in another PR).