### PR TITLE
Match on first element if wrapped value is an array 

### DIFF
--- a/lib/dry/matcher/result_matcher.rb
+++ b/lib/dry/matcher/result_matcher.rb
@@ -2,6 +2,18 @@ require "dry/matcher"
 
 module Dry
   class Matcher
+    match = ::Proc.new do |value, patterns|
+      if patterns.empty?
+        value
+      elsif value.is_a?(::Array) && patterns.any? { |p| p === value[0] }
+        value
+      elsif patterns.any? { |p| p === value }
+        value
+      else
+        Undefined
+      end
+    end
+
     # Built-in {Matcher} ready to use with `Result` or `Try` monads from
     # [dry-monads](/gems/dry-monads) or any other compatible gems.
     #
@@ -48,18 +60,30 @@ module Dry
     #     m.success { |v| "#{v.inspect} is truthy" }
     #     m.failure { |v| "#{v.inspect} is falsey" }
     #   end # => "nil is falsey"
+    #
+    # @example Usage with error codes
+    #   value = Dry::Monads::Result::Failure.new([:invalid, :reasons])
+    #
+    #   Dry::Matcher::ResultMatcher.(value) do |m|
+    #     m.success do |v|
+    #       "Yay: #{v}"
+    #     end
+    #
+    #     m.failure(:not_found) do
+    #       "No such thing"
+    #     end
+    #
+    #     m.failure(:invalid) do |_code, errors|
+    #       "Cannot be done: #{errors.inspect}"
+    #     end
+    #   end #=> "Cannot be done: :reasons"
+    #
     ResultMatcher = Dry::Matcher.new(
       success: Case.new { |result, patterns|
         result = result.to_result
 
         if result.success?
-          value = result.value!
-
-          if patterns.empty? || patterns.any? { |p| p === value }
-            value
-          else
-            Undefined
-          end
+          match.(result.value!, patterns)
         else
           Undefined
         end
@@ -68,13 +92,7 @@ module Dry
         result = result.to_result
 
         if result.failure?
-          value = result.failure
-
-          if patterns.empty? || patterns.any? { |p| p === value }
-            value
-          else
-            Undefined
-          end
+          match.(result.failure, patterns)
         else
           Undefined
         end

--- a/lib/dry/matcher/result_matcher.rb
+++ b/lib/dry/matcher/result_matcher.rb
@@ -49,20 +49,36 @@ module Dry
     #     m.failure { |v| "#{v.inspect} is falsey" }
     #   end # => "nil is falsey"
     ResultMatcher = Dry::Matcher.new(
-      success: Case.new(
-        match: -> result, *patterns {
-          result = result.to_result
-          result.success? && (patterns.empty? || patterns.any? { |p| p === result.value! })
-        },
-        resolve: -> result { result.to_result.value! },
-      ),
-      failure: Case.new(
-        match: -> result, *patterns {
-          result = result.to_result
-          result.failure? && (patterns.empty? || patterns.any? { |p| p === result.failure })
-        },
-        resolve: -> result { result.to_result.failure },
-      )
+      success: Case.new { |result, patterns|
+        result = result.to_result
+
+        if result.success?
+          value = result.value!
+
+          if patterns.empty? || patterns.any? { |p| p === value }
+            value
+          else
+            Undefined
+          end
+        else
+          Undefined
+        end
+      },
+      failure: Case.new { |result, patterns|
+        result = result.to_result
+
+        if result.failure?
+          value = result.failure
+
+          if patterns.empty? || patterns.any? { |p| p === value }
+            value
+          else
+            Undefined
+          end
+        else
+          Undefined
+        end
+      }
     )
   end
 end

--- a/spec/integration/result_matcher_spec.rb
+++ b/spec/integration/result_matcher_spec.rb
@@ -81,4 +81,31 @@ RSpec.describe "Dry::Matcher::ResultMatcher" do
       Success(Time.new(2019, 7, 13)) => 'Matched date success: 2019-07-13',
     )
   end
+
+  context 'matching tuples using codes' do
+    subject {
+      Dry::Matcher::ResultMatcher.(result) do |on|
+        on.success(:created) { |code, s| "Matched #{code.inspect} by code: #{s.inspect}" }
+        on.success(:updated) { |_, s, v| "Matched :updated by code: #{s.inspect}, #{v.inspect}" }
+        on.success(:deleted) { |_, s| "Matched :deleted by code: #{s.inspect}" }
+        on.success(Symbol) { |sym, s| "Matched #{sym.inspect} by Symbol: #{s.inspect}" }
+        on.success(200...300) { |status, _, body| "Matched #{status} body: #{body}" }
+        on.success { |v| "Matched general success: #{v.inspect}" }
+        on.failure(:not_found) { |_, e| "Matched not found with #{e.inspect}" }
+        on.failure('not_found') { |e| "Matched not found by string: #{e.inspect}" }
+        on.failure { |v| "Matched general failure: #{v.inspect}" }
+      end
+    }
+
+    set_up_expectations(
+      Success([:created, 5]) => 'Matched :created by code: 5',
+      Success([:updated, 6, 7]) => 'Matched :updated by code: 6, 7',
+      Success([:deleted, 8, 9]) => 'Matched :deleted by code: 8',
+      Success([:else, 10, 11]) => 'Matched :else by Symbol: 10',
+      Success([201, {}, "done!"]) => 'Matched 201 body: done!',
+      Success(['complete']) => 'Matched general success: ["complete"]',
+      Failure([:not_found, :for_a_reason]) => 'Matched not found with :for_a_reason',
+      Failure(:other) => 'Matched general failure: :other'
+    )
+  end
 end


### PR DESCRIPTION
This finally adds matching by error code:

```ruby
value = Dry::Monads::Result::Failure.new([:invalid, :reasons])

Dry::Matcher::ResultMatcher.(value) do |m|
  m.success do |v|
    "Yay: #{v}"
  end
  
  m.failure(:not_found) do
    "No such thing"
  end
  
  m.failure(:invalid) do |_code, errors|
    "Cannot be done: #{errors.inspect}"
  end
end #=> "Cannot be done: :reasons"
```
It works the same way for both Success and Failure constructors.