### PR TITLE
Turn evaluator into an Object descendant

### DIFF
--- a/lib/dry/matcher/evaluator.rb
+++ b/lib/dry/matcher/evaluator.rb
@@ -5,7 +5,7 @@ module Dry
     NonExhaustiveMatchError = Class.new(StandardError)
 
     # {Evaluator} is used in {Dry::Matcher#call Dry::Matcher#call} block to handle different {Case}s
-    class Evaluator < BasicObject
+    class Evaluator
       # @param [Object] result
       # @param [Hash{Symbol => Case}] cases
       def initialize(result, cases)


### PR DESCRIPTION
Since the evaluator is an object that the user has access to, it can
lead to all sorts of confusing situations when it's misused and it's
not responding to standard Object methods. There's no good reason why
it should be a BasicObject, since it's not exposing any complex DSL.

Closes #31