### PR TITLE
Add MaybeMatcher

### DIFF
--- a/docsite/source/maybe-matcher.html.md
+++ b/docsite/source/maybe-matcher.html.md
@@ -1,0 +1,30 @@
+---
+title: Maybe matcher
+layout: gem-single
+name: dry-matcher
+---
+
+dry-matcher provides a ready-to-use `MaybeMatcher` for working with `Maybe` from [dry-monads](/gems/dry-monads) or any other compatible gems.
+
+```ruby
+require "dry/monads/maybe"
+require "dry/matcher/maybe_matcher"
+
+value = Dry::Monads::Maybe("success!")
+
+result = Dry::Matcher::MaybeMatcher.(value) do |m|
+  m.some(Integer) do |i|
+    "Got int: #{i}"
+  end
+
+  m.some do |v|
+    "Yay: #{v}"
+  end
+
+  m.none do
+    "Boo: none"
+  end
+end
+
+result # => "Yay: success!"
+```

--- a/lib/dry/matcher/match.rb
+++ b/lib/dry/matcher/match.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'dry/matcher'
+
+module Dry
+  class Matcher
+    PatternMatch = ::Proc.new do |value, patterns|
+      if patterns.empty?
+        value
+      elsif value.is_a?(::Array) && patterns.any? { |p| p === value[0] }
+        value
+      elsif patterns.any? { |p| p === value }
+        value
+      else
+        Undefined
+      end
+    end
+  end
+end

--- a/lib/dry/matcher/maybe_matcher.rb
+++ b/lib/dry/matcher/maybe_matcher.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'dry/matcher'
+require "dry/matcher/match"
+
+module Dry
+  class Matcher
+    # Built-in {Matcher} ready to use with `Maybe` monad from
+    # [dry-monads](/gems/dry-monads) or any other compatible gems.
+    #
+    # Provides {Case}s for two matchers:
+    # * `:some` matches `Dry::Monads::Maybe::Some`
+    # * `:none` matches `Dry::Monads::Maybe::None`
+    #
+    # @return [Dry::Matcher]
+    #
+    # @example Usage with `dry-monads`
+    #   require 'dry/monads/maybe'
+    #   require 'dry/matcher/maybe_matcher'
+    #
+    #   value = Dry::Monads::Maybe.new('there is a value!')
+    #
+    #   Dry::Matcher::MaybeMatcher.(value) do |m|
+    #     m.some do |v|
+    #       "Yay: #{v}"
+    #     end
+    #
+    #     m.none do
+    #       "Boo: none"
+    #     end
+    #   end #=> "Yay: there is a value!"
+    #
+    #
+    # @example Usage with specific types
+    #   value = Dry::Monads::Maybe.new([200, :ok])
+    #
+    #   Dry::Matcher::MaybeMatcher.(value) do |m|
+    #     m.some(200, :ok) do |code, value|
+    #       "Yay: #{value}"
+    #     end
+    #
+    #     m.none do
+    #       "Boo: none"
+    #     end
+    #   end #=> "Yay: :ok"
+    #
+    MaybeMatcher = Dry::Matcher.new(
+      some: Case.new { |maybe, patterns|
+        if maybe.none?
+          Undefined
+        else
+          Dry::Matcher::PatternMatch.(maybe.value!, patterns)
+        end
+      },
+      none: Case.new { |maybe|
+        if maybe.some?
+          Undefined
+        end
+      }
+    )
+  end
+end

--- a/lib/dry/matcher/result_matcher.rb
+++ b/lib/dry/matcher/result_matcher.rb
@@ -1,21 +1,10 @@
 # frozen_string_literal: true
 
 require 'dry/matcher'
+require "dry/matcher/match"
 
 module Dry
   class Matcher
-    match = ::Proc.new do |value, patterns|
-      if patterns.empty?
-        value
-      elsif value.is_a?(::Array) && patterns.any? { |p| p === value[0] }
-        value
-      elsif patterns.any? { |p| p === value }
-        value
-      else
-        Undefined
-      end
-    end
-
     # Built-in {Matcher} ready to use with `Result` or `Try` monads from
     # [dry-monads](/gems/dry-monads) or any other compatible gems.
     #
@@ -85,7 +74,7 @@ module Dry
         result = result.to_result
 
         if result.success?
-          match.(result.value!, patterns)
+          Dry::Matcher::PatternMatch.(result.value!, patterns)
         else
           Undefined
         end
@@ -94,7 +83,7 @@ module Dry
         result = result.to_result
 
         if result.failure?
-          match.(result.failure, patterns)
+          Dry::Matcher::PatternMatch.(result.failure, patterns)
         else
           Undefined
         end

--- a/spec/integration/maybe_matcher_spec.rb
+++ b/spec/integration/maybe_matcher_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "date"
+require "dry/monads"
+require "dry/matcher/maybe_matcher"
+
+RSpec.describe "Dry::Matcher::MaybeMatcher" do
+  extend Dry::Monads[:maybe]
+  include Dry::Monads[:maybe]
+
+  before { Object.send(:remove_const, :Operation) if defined? Operation }
+
+  def self.set_up_expectations(matches)
+    matches.each do |value, matched|
+      context "Matching #{value}" do
+        let(:result) { value }
+
+        it { is_expected.to eql(matched) }
+      end
+    end
+  end
+
+  describe "external matching" do
+    subject do
+      Dry::Matcher::MaybeMatcher.(result) do |m|
+        m.some do |v|
+          "Matched some: #{v}"
+        end
+
+        m.none do
+          "Matched none"
+        end
+      end
+    end
+
+    set_up_expectations(
+      Some("a success") => "Matched some: a success",
+      None() => "Matched none",
+    )
+  end
+
+  context "multiple branch matching" do
+    subject do
+      Dry::Matcher::MaybeMatcher.(result) do |on|
+        on.some(:a) { "Matched specific success: :a" }
+        on.some(:b) { "Matched specific success: :b" }
+        on.some { |v| "Matched general success: #{v}" }
+        on.none { "Matched none" }
+      end
+    end
+
+    set_up_expectations(
+      Some(:a) => "Matched specific success: :a",
+      Some(:b) => "Matched specific success: :b",
+      Some("a success") => "Matched general success: a success",
+      None() => "Matched none",
+    )
+  end
+
+  context "using ===" do
+    subject do
+      Dry::Matcher::MaybeMatcher.(result) do |on|
+        on.some(/done/) { |s| "Matched string by pattern: #{s.inspect}" }
+        on.some(String) { |s| "Matched string success: #{s.inspect}" }
+        on.some(Integer) { |n| "Matched integer success: #{n}" }
+        on.some(Date, Time) { |t| "Matched date success: #{t.strftime('%Y-%m-%d')}" }
+        on.some { |v| "Matched general success: #{v}" }
+        on.none { "Matched none" }
+      end
+    end
+
+    set_up_expectations(
+      Some("nicely done") => 'Matched string by pattern: "nicely done"',
+      Some("yay") => 'Matched string success: "yay"',
+      Some(3) => "Matched integer success: 3",
+      Some(Date.new(2019, 7, 13)) => "Matched date success: 2019-07-13",
+      Some(Time.new(2019, 7, 13)) => "Matched date success: 2019-07-13",
+      None() => "Matched none"
+    )
+  end
+
+  context "matching tuples using codes" do
+    subject do
+      Dry::Matcher::MaybeMatcher.(result) do |on|
+        on.some(:created) { |code, s| "Matched #{code.inspect} by code: #{s.inspect}" }
+        on.some(:updated) { |_, s, v| "Matched :updated by code: #{s.inspect}, #{v.inspect}" }
+        on.some(:deleted) { |_, s| "Matched :deleted by code: #{s.inspect}" }
+        on.some(Symbol) { |sym, s| "Matched #{sym.inspect} by Symbol: #{s.inspect}" }
+        on.some(200...300) { |status, _, body| "Matched #{status} body: #{body}" }
+        on.some { |v| "Matched general success: #{v.inspect}" }
+        on.none { "Matched none" }
+      end
+    end
+
+    set_up_expectations(
+      Some([:created, 5]) => "Matched :created by code: 5",
+      Some([:updated, 6, 7]) => "Matched :updated by code: 6, 7",
+      Some([:deleted, 8, 9]) => "Matched :deleted by code: 8",
+      Some([:else, 10, 11]) => "Matched :else by Symbol: 10",
+      Some([201, {}, "done!"]) => "Matched 201 body: done!",
+      Some(["complete"]) => 'Matched general success: ["complete"]',
+      None() => "Matched none"
+    )
+  end
+
+  context "with .for" do
+    let(:operation) do
+      class Operation
+        include Dry::Matcher::MaybeMatcher.for(:perform)
+
+        def perform(value)
+          value
+        end
+      end
+      Operation.new
+    end
+
+    context "using with methods" do
+      def match(value)
+        operation.perform(value) do |m|
+          m.some { |v| "success: #{v}" }
+          m.none { "none" }
+        end
+      end
+
+      it "builds a wrapping module" do
+        expect(match(Some(:foo))).to eql("success: foo")
+        expect(match(None())).to eql("none")
+      end
+    end
+
+    context "with keyword arguments" do
+      let(:operation) do
+        class Operation
+          include Dry::Matcher::MaybeMatcher.for(:perform)
+
+          def perform(value:)
+            value
+          end
+        end
+        Operation.new
+      end
+
+      it "works without a warning" do
+        result = operation.perform(value: Some(1)) do |m|
+          m.some { |v| v }
+          m.none { raise }
+        end
+
+        expect(result).to be(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Pretty much the same as the `ResultMatcher` tool, but for the `Maybe` monad:

```ruby
Dry::Matcher::MaybeMatcher.(Maybe(2)) do |m|
  m.some(Integer) do |i|
    "Got int: #{i}"
  end

  m.some do |v|
    "Yay: #{v}"
  end

  m.none do
    "Boo: none"
  end
end # Got int: 2
```